### PR TITLE
Configures release to npm when a tag is pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,11 @@ language: node_js
 node_js:
 - '6'
 script: npm run build
+deploy:
+  provider: npm
+  email: charles_treatman@cable.comcast.com
+  api_key:
+    secure: ek9cjerAEM2voSyO7RY/erKlvLz+Stn1ByMrhhpTKXg/vF4EwwJq/9DsHWsMr0wd8Kxk3TTBbxnEmgCyDDkF0R1T7rtExPa6yiTiuuV+OHTrKhySwmAc4S8lIoTVtf60oXpJmQkdcYNDZblYTmLNL6q0+19ATBbLr3lpHEC8XxHffxxg98rc+DntZnoWRUNnf/ZqMcILRzYgwQL/WoCTBwlGntgyK9ClsKNhjtEt993bJovh1cFdjk888xGCBStToHMHMQu2NoS89jJdgpCA8YDV5t/lEfx2aI71H9CwhthHHVpTOewlRRjelaM8mvOd58igXdjWTNNKSVvmPVLwCeb382jPzquurD8H4WuAEQJxCunWs+wnEcjtoCRziZo44dr66fC6cYTmMXUQ3ZtlZTIG2t/d9/Xk6cRHNucuqGeK0BMbvluTx1qWpOAFtV2wu9mJWG2ecmm6Eg7XNORHP3U59BeLwB7zRNappFwZ2vjIrRfhLjjHwrgNFLNtbmenMoiaYm9DkbhPSY/WYkG8VwavXeP93y2C/ADgYdFvZMICkwRrJ1TtkxFbWfptTgXd5Beten+t47efGChCERUJu5AI9qw1URQ4pr5k1KNaTPtIzApqxWjefg/ul9dHf2QeqeC6A62uuqETdZcOwfT2BF0MrDiWaxSYFDwKw4yJCAw=
+  on:
+    tags: true
+    repo: Comcast/hypergard

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "hyperGard",
+  "name": "hypergard",
   "version": "5.1.0",
   "repository": "git@github.com:Comcast/hypergard.git",
   "bugs": "https://github.com/Comcast/hypergard/issues",
-  "private": true,
+  "homepage": "https://github.com/Comcast/hypergard",
   "main": "dist/hyperGard.js",
   "module": "dist/hyperGard.es.js",
   "devDependencies": {
@@ -49,5 +49,10 @@
   "directories": {
     "test": "test"
   },
+  "files": [
+    "src/**/*",
+    "lib/**/*",
+    "dist/**/*"
+  ],
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
Publishing hypergard to the public npm package repo makes it easier
for someone to start using the library.  This updates the Travis CI
config to publish the package to npm upon successful build of a git
tag.

With this configuration, our release process will be:

  - Ensure that the version in package.json is updated in master
  - Create a tag with the same name as the version number
  - Push the new tag to GitHub